### PR TITLE
Fix backup cleanup glob expansion

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -108,7 +108,11 @@ backup_file() {
     cp "$src" "$backup_name"
     log INFO "Backup created: $backup_name"
 
-    local backups=("$BACKUP_DIR/$(basename "$src")_*.bak")
+    # Expand the backup glob to an array of existing files
+    shopt -s nullglob
+    local backups=("$BACKUP_DIR"/$(basename "$src")_*.bak)
+    shopt -u nullglob
+
     if [ "${#backups[@]}" -gt "$BACKUP_MAX_COUNT" ]; then
       local excess_count=$((${#backups[@]} - BACKUP_MAX_COUNT))
       for old_backup in $(ls -t "${backups[@]}" | tail -n $excess_count); do


### PR DESCRIPTION
## Summary
- ensure glob expansion when pruning old backups in `bin/install.sh`

## Testing
- `bash -n bin/install.sh`
- `bash -n bin/clean.sh`
- `bash -n bin/list.sh`
- `shellcheck bin/install.sh`
- `shellcheck bin/clean.sh`
- `shellcheck bin/list.sh`


------
https://chatgpt.com/codex/tasks/task_e_685fe644ee08832d860fc778375f9ab9