### PR TITLE
Revert env restructuring and add OS README placeholders

### DIFF
--- a/env/common/README.md
+++ b/env/common/README.md
@@ -1,0 +1,3 @@
+# Common environment
+
+Files shared among all environments.

--- a/env/fedora/README.md
+++ b/env/fedora/README.md
@@ -1,0 +1,3 @@
+# Fedora environment
+
+Configuration specific to Fedora Linux.

--- a/env/mac/README.md
+++ b/env/mac/README.md
@@ -1,0 +1,3 @@
+# macOS environment
+
+Configuration specific to macOS.

--- a/env/wsl/README.md
+++ b/env/wsl/README.md
@@ -1,0 +1,3 @@
+# WSL environment
+
+Configuration specific to Windows Subsystem for Linux.


### PR DESCRIPTION
## Summary
- revert dotfile restructuring to restore original setup
- add placeholder README files under env/common, env/fedora, env/mac, and env/wsl

## Testing
- `shellcheck .bashrc .bashrc.d/*.sh`
- `bash -n .bashrc .bashrc.d/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68602798f028832daa05712f0c8745a3