### PR TITLE
Fix list.sh equality tests

### DIFF
--- a/bin/list.sh
+++ b/bin/list.sh
@@ -7,10 +7,10 @@ if [ -d "${DOT_DIR}" ]; then
   cd "${DOT_DIR}" || exit 1
   echo "Show list of available dotfiles in dotfiles repository..."
   for f in .??*; do
-    [ "$f" "=" ".git" ] && continue
-    [ "$f" "=" ".github" ] && continue
-    [ "$f" "=" ".gitignore" ] && continue
-    [ "$f" "=" ".gitattributes" ] && continue
+    [ "$f" = ".git" ] && continue
+    [ "$f" = ".github" ] && continue
+    [ "$f" = ".gitignore" ] && continue
+    [ "$f" = ".gitattributes" ] && continue
 
     echo "${HOME}/$f"
   done


### PR DESCRIPTION
## Summary
- fix equality operator syntax in `list.sh`

## Testing
- `shellcheck bin/list.sh`
- `bash bin/list.sh`

------
https://chatgpt.com/codex/tasks/task_e_68602c9674c0832da45c5305fc8cbc45