### PR TITLE
Implement env/common installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,3 @@ Download this repo and make symlinks for dotfiles.
 ```sh
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/hskwakr/dotfiles/main/bin/install.sh)"
 ```
-
-The installer clones the repository to `~/dotfiles` and links files found in
-`env/common` into your home directory. Root-level dotfiles are not linked by
-default.
-

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Download this repo and make symlinks for dotfiles.
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/hskwakr/dotfiles/main/bin/install.sh)"
 ```
 
+The installer clones the repository to `~/dotfiles` and links files found in
+`env/common` into your home directory. Root-level dotfiles are not linked by
+default.
+


### PR DESCRIPTION
## Summary
- add `prepare_repo` and `install_env_common` helpers
- keep root dotfile installation in `install_root_dotfiles`
- call the new helpers from `main`
- document env/common behavior in README

## Testing
- `bash -n bin/install.sh`
- `shellcheck bin/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68626eebaa08832d888073a49bb97be1