### PR TITLE
Add symlink no-backup test for backup_and_link

### DIFF
--- a/test/install_functions/backup_and_link.bats
+++ b/test/install_functions/backup_and_link.bats
@@ -58,3 +58,14 @@ teardown() {
   [ -L "$HOME/file" ]
   [ "$(readlink "$HOME/file")" = "$DOTFILES_DIR/srcfile" ]
 }
+
+@test "no backup when symlink already correct" {
+  echo "src" > "$DOTFILES_DIR/srcfile"
+  ln -s "$DOTFILES_DIR/srcfile" "$HOME/file"
+  run backup_and_link "$DOTFILES_DIR/srcfile" "$HOME/file"
+  [ "$status" -eq 0 ]
+  shopt -s nullglob
+  backups=("$BACKUP_DIR"/file_*.bak)
+  shopt -u nullglob
+  [ "${#backups[@]}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add regression test ensuring `backup_and_link` doesn't create backups when the
  destination already links to the source

## Testing
- `bats --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_6868ba002738832dab84c4661f0bfe44