### PR TITLE
Add rotation test for multiple backups

### DIFF
--- a/test/install_functions/manage_log_file.bats
+++ b/test/install_functions/manage_log_file.bats
@@ -40,3 +40,17 @@ teardown() {
   [ -f "$LOG_FILE.2" ]
   [ ! -f "$LOG_FILE.3" ]
 }
+
+@test "shifts existing backups when rotated" {
+  LOG_BACKUP_COUNT=3
+  printf 'current_log' > "$LOG_FILE"
+  printf 'first_backup' > "$LOG_FILE.1"
+  printf 'second_backup' > "$LOG_FILE.2"
+  run manage_log_file "$LOG_FILE"
+  [ "$status" -eq 0 ]
+  grep -q 'second_backup' "$LOG_FILE.3"
+  grep -q 'first_backup' "$LOG_FILE.2"
+  grep -q 'current_log' "$LOG_FILE.1"
+  [ ! -f "$LOG_FILE.4" ]
+  grep -q 'Log rotated' "$LOG_FILE"
+}


### PR DESCRIPTION
## Summary
- cover log rotation when more than two backups exist

## Testing
- `bats --recursive test/install_functions/manage_log_file.bats`
- `bats --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_6868bcc42ba0832d955e8cfb3883060a