### PR TITLE
Add test for missing log file in manage_log_file

### DIFF
--- a/test/install_functions/manage_log_file.bats
+++ b/test/install_functions/manage_log_file.bats
@@ -30,6 +30,16 @@ teardown() {
   grep -q 'Log rotated' "$LOG_FILE"
 }
 
+@test "does nothing when log file absent" {
+  run manage_log_file "$LOG_FILE"
+  [ "$status" -eq 0 ]
+  [ ! -e "$LOG_FILE" ]
+  shopt -s nullglob
+  logs=("$LOG_DIR"/*)
+  shopt -u nullglob
+  [ "${#logs[@]}" -eq 0 ]
+}
+
 @test "keeps limited number of backups" {
   printf 'abc' > "$LOG_FILE"
   printf 'old1' > "$LOG_FILE.1"


### PR DESCRIPTION
## Summary
- add regression test covering absence of LOG_FILE

## Testing
- `bats --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_6868bf253a14832d8975d3ff691bc133