### PR TITLE
Add test to confirm install ignores root-level files

### DIFF
--- a/test/install.bats
+++ b/test/install.bats
@@ -37,3 +37,14 @@ teardown() {
   shopt -u nullglob
   [ "${#backups[@]}" -ge 1 ]
 }
+
+@test "install.sh does not link root-level dotfiles" {
+  echo "keep" > "$HOME/.bashrc"
+
+  run bash "$BATS_TEST_DIRNAME/../bin/install.sh" -d "$REPO"
+  [ "$status" -eq 0 ]
+
+  [ ! -L "$HOME/.bashrc" ]
+  grep -q "keep" "$HOME/.bashrc"
+  [ ! -e "$REPO/backups/original/.bashrc" ]
+}


### PR DESCRIPTION
## Summary
- verify that `install.sh` leaves non-env dotfiles untouched

## Testing
- `bats --formatter pretty --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_68691bdb1bb8832d8a23a38dea88105a