### PR TITLE
Use script wrapper for BATS in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Run BATS tests
         env:
           TERM: xterm
-        run: bats --formatter pretty --recursive test
+        run: script -q -c "bats --formatter pretty --recursive test" /dev/null

--- a/doc/projects/testing.md
+++ b/doc/projects/testing.md
@@ -32,4 +32,4 @@ Docker イメージは `bats/bats:latest` をベースにしており、ビル�
 
 ## CI での自動実行
 
-このリポジトリでは Pull Request 作成時に GitHub Actions が自動で BATS テストを実行します。ワークフローの定義は `.github/workflows/test.yml` を参照してください。`TERM` を `xterm` に設定してから `bats --formatter pretty --recursive test` を実行し、非対話環境でも色付き出力を有効にしています。
+このリポジトリでは Pull Request 作成時に GitHub Actions が自動で BATS テストを実行します。ワークフローの定義は `.github/workflows/test.yml` を参照してください。`TERM` を `xterm` に設定し、`script` コマンド経由で `bats --formatter pretty --recursive test` を実行することで、CI 環境で出力が重複する問題を防いでいます。


### PR DESCRIPTION
## Summary
- wrap `bats` command with `script` in CI workflow
- document use of `script` to avoid duplicate output

## Testing
- `bats --formatter pretty --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_6869abb4bc20832d8f0c57d828b90d9e