### PR TITLE
Add test to ensure clean.sh keeps unrelated files

### DIFF
--- a/test/clean.bats
+++ b/test/clean.bats
@@ -45,3 +45,17 @@ teardown() {
   [ ! -e "$REPO/backups/old.bak" ]
   [ ! -e "$REPO/logs/old.log" ]
 }
+
+@test "clean.sh keeps unrelated files" {
+  echo "keep" > "$HOME/keepfile"
+  echo "repo" > "$REPO/keepfile"
+
+  run bash "$BATS_TEST_DIRNAME/../bin/clean.sh"
+  [ "$status" -eq 0 ]
+
+  [ -f "$HOME/keepfile" ]
+  grep -q "keep" "$HOME/keepfile"
+
+  [ -f "$REPO/keepfile" ]
+  grep -q "repo" "$REPO/keepfile"
+}


### PR DESCRIPTION
## Summary
- expand clean.bats to verify unrelated files remain intact after running `clean.sh`

## Testing
- `bats --formatter pretty test/clean.bats` *(fails: `bash: bats: command not found`)*
- `./test/run_tests.sh test/clean.bats` *(fails: `Docker is required to run tests`)*

------
https://chatgpt.com/codex/tasks/task_e_686a955e7ca8832d959588dddf38579f