### PR TITLE
Add test for re-linking already linked items

### DIFF
--- a/test/install_functions/link_directory.bats
+++ b/test/install_functions/link_directory.bats
@@ -70,3 +70,22 @@ teardown() {
   [ -L "$HOME/dest/.hidden" ]
   [ "$(readlink "$HOME/dest/.hidden")" = "$DOTFILES_DIR/src/.hidden" ]
 }
+
+@test "skips existing links and processes remaining items" {
+  mkdir -p "$DOTFILES_DIR/src"
+  echo "first" > "$DOTFILES_DIR/src/file1"
+  echo "second" > "$DOTFILES_DIR/src/file2"
+
+  # Initial linking
+  run link_directory "$DOTFILES_DIR/src" "$HOME/dest"
+  [ "$status" -eq 0 ]
+
+  # Run again to ensure already linked file1 does not block file2
+  run link_directory "$DOTFILES_DIR/src" "$HOME/dest"
+  [ "$status" -eq 0 ]
+
+  [ -L "$HOME/dest/file1" ]
+  [ "$(readlink "$HOME/dest/file1")" = "$DOTFILES_DIR/src/file1" ]
+  [ -L "$HOME/dest/file2" ]
+  [ "$(readlink "$HOME/dest/file2")" = "$DOTFILES_DIR/src/file2" ]
+}


### PR DESCRIPTION
## Summary
- ensure `link_directory` continues after encountering existing links

## Testing
- `bats --formatter pretty --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_686aa6e0166c832d9d3139afdde719a7