### PR TITLE
Fix install script to use strict mode

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -8,7 +8,7 @@
 # Description:
 #   This script links dotfiles to the home directory and optionally changes the default shell.
 
-set -e
+set -euo pipefail
 
 # Configuration Variables
 # -----------------------


### PR DESCRIPTION
## Summary
- use `set -euo pipefail` for consistent error handling

## Testing
- `bats --formatter pretty --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_686aed914958832dafea7a1c09e82258