### PR TITLE
feat: Add macOS-specific .gitconfig with Homebrew gh path

### DIFF
--- a/env/macOS/.gitconfig
+++ b/env/macOS/.gitconfig
@@ -1,0 +1,11 @@
+[user]
+	name = hskwakr
+	email = 33633391+hskwakr@users.noreply.github.com
+[alias]
+	lol = log --graph --decorate --pretty=oneline --all --abbrev-commit
+[init]
+	defaultBranch = main
+[credential "https://github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential


### PR DESCRIPTION
## Summary
- `env/macOS/.gitconfig` を追加し、credential helper に `/opt/homebrew/bin/gh` を指定
- macOS (Homebrew) 環境で `git push` 等の認証が失敗する問題を解決

Closes #91

## 背景
`env/common/.gitconfig` の credential helper に `/usr/bin/gh` がハードコードされているが、macOS では `gh` は `/opt/homebrew/bin/gh` にあるため認証エラーになる。#84 で導入された OS 固有ファイルの優先処理 (last-wins) を活用して macOS 版で override する。

## 既知の制約
- 共通設定 (user, alias, init) が common と macOS で重複している → #82 で構造改善を検討中
- Intel Mac (`/usr/local/bin/gh`) には未対応 → #93 で追跡中

## Test plan
- [ ] macOS 環境で `bin/install.sh` を実行し、`~/.gitconfig` が `env/macOS/.gitconfig` へのシンボリックリンクになることを確認
- [ ] `git push` で credential helper が正しく動作することを確認
- [ ] Linux 環境で `env/common/.gitconfig` が引き続き使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)